### PR TITLE
Fix Not Resuming on July 22 Steam Client Update

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -13,8 +13,8 @@ import {
 } from "./interop";
 import { Settings } from "./settings";
 import {
-  getResumeObservable,
-  getSuspendObservable,
+  //getResumeObservable,
+  getSuspendResumeObservable,
 } from "./sleep/suspendResumeObservables";
 
 // only the needed subset of the SteamClient
@@ -281,28 +281,27 @@ export function setupSuspendResumeHandler(): () => void {
   // const { unregister: unregisterOnResumeFromSuspend } =
   //   SteamClient.System.RegisterForOnResumeFromSuspend(onResume);
 
-  const suspendObservable = getSuspendObservable();
-  const resumeObservable = getResumeObservable();
+  const suspendresumeObservable = getSuspendResumeObservable();
+  //const resumeObservable = getResumeObservable();
 
-  const unregisterOnSuspendRequest = suspendObservable?.observe_((change) => {
+  // Note: If newValue is TRUE then it's suspending, otherwise it's resuming.
+  const unregisterOnSuspendRequest = suspendresumeObservable?.observe_((change) => {
     const { newValue } = change;
-    console.log({ info: `change value ${change}` });
     console.log({ info: `PG-Suspending: mobX suspend triggered with ${newValue}` });
     if (!newValue) {
       return;
     }
-    console.log({ info: `PG: Suspending Games...` });
+    console.log({ info: `PG: Suspending Games (If toggle is enabled)...` });
     onSuspend();
   });
 
-  const unregisterOnResumeFromSuspend = suspendObservable?.observe_((change) => {
+  const unregisterOnResumeFromSuspend = suspendresumeObservable?.observe_((change) => {
     const { newValue } = change;
-    console.log({ info: `change value ${change}` });
     console.log({ info: `PG-Resuming: mobX suspend triggered with ${newValue}` });
     if (newValue) {
       return;
     }
-    console.log({ info: `PG: Resuming Games...` });
+    console.log({ info: `PG: Resuming Games (If toggle is enabled)...` });
     onResume();
   });
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -287,7 +287,7 @@ export function setupSuspendResumeHandler(): () => void {
   const unregisterOnSuspendRequest = suspendObservable?.observe_((change) => {
     const { newValue } = change;
     console.log({ info: `change value ${change}` });
-    console.log({ info: `mobX suspend triggered with ${newValue}` });
+    console.log({ info: `PG-Suspending: mobX suspend triggered with ${newValue}` });
     if (!newValue) {
       return;
     }
@@ -295,10 +295,10 @@ export function setupSuspendResumeHandler(): () => void {
     onSuspend();
   });
 
-  const unregisterOnResumeFromSuspend = resumeObservable?.observe_((change) => {
+  const unregisterOnResumeFromSuspend = suspendObservable?.observe_((change) => {
     const { newValue } = change;
     console.log({ info: `change value ${change}` });
-    console.log({ info: `mobX resume triggered with ${newValue}` });
+    console.log({ info: `PG-Resuming: mobX suspend triggered with ${newValue}` });
     if (newValue) {
       return;
     }

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -299,7 +299,7 @@ export function setupSuspendResumeHandler(): () => void {
     const { newValue } = change;
     console.log({ info: `change value ${change}` });
     console.log({ info: `mobX resume triggered with ${newValue}` });
-    if (!newValue) {
+    if (newValue) {
       return;
     }
     console.log({ info: `PG: Resuming Games...` });

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -286,19 +286,23 @@ export function setupSuspendResumeHandler(): () => void {
 
   const unregisterOnSuspendRequest = suspendObservable?.observe_((change) => {
     const { newValue } = change;
+    console.log({ info: `change value ${change}` });
     console.log({ info: `mobX suspend triggered with ${newValue}` });
     if (!newValue) {
       return;
     }
+    console.log({ info: `PG: Suspending Games...` });
     onSuspend();
   });
 
   const unregisterOnResumeFromSuspend = resumeObservable?.observe_((change) => {
     const { newValue } = change;
+    console.log({ info: `change value ${change}` });
     console.log({ info: `mobX resume triggered with ${newValue}` });
     if (!newValue) {
       return;
     }
+    console.log({ info: `PG: Resuming Games...` });
     onResume();
   });
 

--- a/src/sleep/suspendResumeObservables.ts
+++ b/src/sleep/suspendResumeObservables.ts
@@ -33,7 +33,7 @@ declare global {
   let SuspendResumeStore: SuspendResumeStoreType;
 }
 
-export function getSuspendObservable() {
+export function getSuspendResumeObservable() {
   const suspendingMobXObservable = getMobxObservable(
     SuspendResumeStore,
     "m_bSuspending",
@@ -41,6 +41,8 @@ export function getSuspendObservable() {
   return suspendingMobXObservable;
 }
 
+// m_bResuming seems to be removed on July 22 2026 Steam Client Stable Update.
+/*
 export function getResumeObservable() {
   const resumingMobXObservable = getMobxObservable(
     SuspendResumeStore,
@@ -49,3 +51,4 @@ export function getResumeObservable() {
 
   return resumingMobXObservable;
 }
+*/


### PR DESCRIPTION
Since mbox `m_bResuming` has been removed, now using `m_bSuspending` stats for suspend/resume.